### PR TITLE
Applied percent-encoding for callback in OAuth1's header

### DIFF
--- a/src/oauth1.nim
+++ b/src/oauth1.nim
@@ -182,7 +182,7 @@ proc getOAuth1RequestHeader*(params: OAuth1Parameters, extraHeaders: string): st
     if params.token != nil:
         result = result & subex(", oauth_token=\"$#\"") % [ params.token ]
     if params.callback != nil:
-        result = result & subex(", oauth_callback=\"$#\"") % [ params.callback ]
+        result = result & subex(", oauth_callback=\"$#\"") % [ percentEncode(params.callback) ]
     if params.verifier != nil:
         result = result & subex(", oauth_verifier=\"$#\"") % [ params.verifier ]
     if params.isIncludeVersionToHeader:


### PR DESCRIPTION
I tried to implement web-flow of Twitter OAuth by using this library, and found that I couldn't get accessToken because callback parameter was not percent-encoded.
According to RFC5849, > https://tools.ietf.org/html/rfc5849#section-3.5.1
all parameter names and values are needed to be percent-encoded, but only callback seems to be affected in real.
and PIN-Based example had worked because "oob" was already fit as percent-encoded string.