### PR TITLE
Fixes this package quitting my program when SSL not available.

### DIFF
--- a/src/oauth1.nim
+++ b/src/oauth1.nim
@@ -271,5 +271,4 @@ when defined(testing):
     assert len(createNonce()) == 32
 
 when not defined(ssl):
-    echo "SSL support is required."
-    quit 1
+    {.error: "SSL support is required.".}

--- a/src/oauth2.nim
+++ b/src/oauth2.nim
@@ -323,5 +323,4 @@ when defined(testing):
     assert header["Content-Length"] == "0"
 
 when not defined(ssl):
-    echo "SSL support is required."
-    quit 1
+    {.error: "SSL support is required.".}


### PR DESCRIPTION
This has caused me quite a headache, please never use `quit` in a library.

For this particular case you should use the compile-time error pragma. When compiling without `-d:ssl` you'll get:

```
C:\Users\Dominik\git\oauth\src\oauth2.nim(326, 12) Error: SSL support is required.
```