### PR TITLE
Remove generateState

### DIFF
--- a/examples/discord.nim
+++ b/examples/discord.nim
@@ -15,7 +15,7 @@
 # Modified for Discord by William Hatcher @williamhatcher
 # date  : 2021-03-27
 
-import uri, json, sequtils, strutils, httpclient
+import base64, uri, json, sequtils, std/sysrand, strutils, httpclient
 import oauth2
 
 const
@@ -31,7 +31,7 @@ echo "Please enter the client secret: "
 let clientSecret = readLine(stdin)
 
 let
-  state = generateState()
+  state = encodeUrl(encode(urandom(128), safe = true))
   grantUrl = getAuthorizationCodeGrantUrl(authorizeUrl, clientId, redirectUri, state, scopes)
 echo "Please go to this url."
 echo grantUrl

--- a/examples/github.nim
+++ b/examples/github.nim
@@ -14,10 +14,12 @@
 # Author: Yoshihiro Tanaka <contact@cordea.jp>
 # date  : 2019-12-22
 
+import base64
 import uri
 import json
 import oauth2
 import sequtils
+import std/sysrand
 import strutils
 import httpclient
 
@@ -33,7 +35,7 @@ echo "Please enter the client secret."
 let clientSecret = readLine(stdin)
 
 let
-  state = generateState()
+  state = encodeUrl(encode(urandom(128), safe = true))
   grantUrl = getAuthorizationCodeGrantUrl(authorizeUrl, clientId, redirectUri, state)
 echo "Please go to this url."
 echo grantUrl

--- a/examples/gmail.nim
+++ b/examples/gmail.nim
@@ -14,7 +14,10 @@
 # Author: Yoshihiro Tanaka <contact@cordea.jp>
 # date  :2016-03-08
 
+import base64
+import uri
 import oauth2
+import std/sysrand
 import strutils
 import httpclient
 import json
@@ -31,7 +34,7 @@ let clientSecret = readLine(stdin)
 
 let
     client = newHttpClient()
-    state = generateState()
+    state = encodeUrl(encode(urandom(128), safe = true))
     grantUrl = getAuthorizationCodeGrantUrl(
       authorizeUrl,
       clientId,

--- a/examples/gmail.nim
+++ b/examples/gmail.nim
@@ -60,7 +60,7 @@ assert state == grantResponse.state
 let
   response = client.getAuthorizationCodeAccessToken(
     accessTokenUrl,
-    grantResponse.code,
+    decodeUrl(grantResponse.code),
     clientId,
     clientSecret,
     redirectUri
@@ -72,7 +72,6 @@ let
     obj = parseJson(response.body)
     accessToken = obj["access_token"].str
     tokenType = obj["token_type"].str
-    refreshToken = obj["refresh_token"].str
 
 if tokenType == "Bearer":
   let r = client.bearerRequest(

--- a/examples/slack.nim
+++ b/examples/slack.nim
@@ -14,9 +14,11 @@
 # Author: Yoshihiro Tanaka <contact@cordea.jp>
 # date  :2016-03-08
 
+import base64
 import uri
 import json
 import oauth2
+import std/sysrand
 import httpclient
 
 const
@@ -31,7 +33,7 @@ echo "Please enter the client secret."
 let clientSecret = readLine(stdin)
 
 let
-  state = generateState()
+  state = encodeUrl(encode(urandom(128), safe = true))
   grantUrl = getAuthorizationCodeGrantUrl(authorizeUrl, clientId, redirectUri, state, @["channels:read"])
 echo "Please go to this url."
 echo grantUrl

--- a/examples/slack.nim
+++ b/examples/slack.nim
@@ -25,7 +25,7 @@ const
     authorizeUrl = "https://slack.com/oauth/authorize"
     accessTokenUrl = "https://slack.com/api/oauth.access"
     redirectUri = "http://localhost:8080"
-    url = "https://slack.com/api/channels.list"
+    url = "https://slack.com/api/conversations.list"
 
 echo "Please enter the client id."
 let clientId = readLine(stdin)

--- a/test/toauth2.nim
+++ b/test/toauth2.nim
@@ -42,9 +42,6 @@ suite "OAuth2 test":
         let header = getBearerRequestHeader("Aladdin")
         assert header["Authorization"] == "Bearer Aladdin"
 
-    test "generate state":
-        assert len(generateState()) == 5
-
     test "parse redirect uri":
         let
             uri = "https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz"


### PR DESCRIPTION
Closes #21.

`generateState` will be removed because, in my understanding, `state` has no length limit according to the RFC (sorry I probably misunderstood in the past), but some services might have limitations due to databases or something else. It's difficult to consider this here. On the other hand, I guess it's easy to generate the state on the user side, like in examples I wrote.